### PR TITLE
Fix: self sign cert

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.service_folder_name}}/infrastructure.tf
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.service_folder_name}}/infrastructure.tf
@@ -282,12 +282,6 @@ resource "null_resource" "cert" {
   provisioner "local-exec" {
     environment = {
       CountryName            = "PL"
-      StateOrProvinceName    = "Masovian"
-      LocalityName           = "Warsaw"
-      OrganizationName       = "Org Name"
-      OrganizationalUnitName = "Org Unit"
-      CommonName             = ""
-      EmailAddress           = ""
     }
     command     = <<EOT
 mkdir -p ./Certs


### PR DESCRIPTION
New way to generata certs. Base on:
https://support.citrix.com/article/CTX135602/how-to-create-a-selfsigned-san-certificate-using-openssl-on-citrix-adc-appliance
https://medium.com/@antelle/how-to-generate-a-self-signed-ssl-certificate-for-an-ip-address-f0dd8dddf754

Tested, working.
Removed unused secret "{workspace}-{env}-airee_pem"